### PR TITLE
Feat/apple login

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -275,6 +275,42 @@
       "integrity": "sha512-f5j5b/Gf71L+dbqxIpQ4Z2WlmI/mPJ0fOkGGmFgtb6sAu97EPczzbS3/tJKxmcYDj55OX6ssqwDAWOHIYDRDGA==",
       "dev": true
     },
+    "@types/oauth": {
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/@types/oauth/-/oauth-0.9.1.tgz",
+      "integrity": "sha512-a1iY62/a3yhZ7qH7cNUsxoI3U/0Fe9+RnuFrpTKr+0WVOzbKlSLojShCKe20aOD1Sppv+i8Zlq0pLDuTJnwS4A==",
+      "requires": {
+        "@types/node": "*"
+      }
+    },
+    "@types/passport": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/@types/passport/-/passport-1.0.6.tgz",
+      "integrity": "sha512-9oKfrJXuAxvyxdrtMCxKkHgmd6DMO8NDOLvMJ1LvIWd6/xP+i81PAkpTaEca7VhJX9S009RciwZL/j6dsLsHrA==",
+      "requires": {
+        "@types/express": "*"
+      }
+    },
+    "@types/passport-apple": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@types/passport-apple/-/passport-apple-1.1.0.tgz",
+      "integrity": "sha512-8iZqR2zFA5oiaKMHJ/iPIjJWbpn0dGBwqnKIaNB0chKzr1PekqQASznITu78xQQztFZerrwHBesjiyZM3afORA==",
+      "requires": {
+        "@types/express": "*",
+        "@types/passport": "*",
+        "@types/passport-oauth2": "*"
+      }
+    },
+    "@types/passport-oauth2": {
+      "version": "1.4.10",
+      "resolved": "https://registry.npmjs.org/@types/passport-oauth2/-/passport-oauth2-1.4.10.tgz",
+      "integrity": "sha512-klShWm9xAqjM3rU31KyMMiB9M8jmJPkStUvCJ/kIv73/Vh3OVnfeTExrkMCM2wA+94MliExqwHVL3J0WD2kbnQ==",
+      "requires": {
+        "@types/express": "*",
+        "@types/oauth": "*",
+        "@types/passport": "*"
+      }
+    },
     "@types/qs": {
       "version": "6.9.5",
       "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.5.tgz",
@@ -657,6 +693,11 @@
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
       "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
+    },
+    "base64url": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/base64url/-/base64url-3.0.1.tgz",
+      "integrity": "sha512-ir1UPr3dkwexU7FdV8qBBbNDRUhMmIekYMFZfi+C/sLNnRESKPl23nB9b2pltqfOQNnGzsDdId90AEtG5tCx4A=="
     },
     "basic-auth": {
       "version": "2.0.1",
@@ -3198,6 +3239,11 @@
         "path-key": "^3.0.0"
       }
     },
+    "oauth": {
+      "version": "0.9.15",
+      "resolved": "https://registry.npmjs.org/oauth/-/oauth-0.9.15.tgz",
+      "integrity": "sha1-vR/vr2hslrdUda7VGWQS/2DPucE="
+    },
     "object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -3387,6 +3433,41 @@
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
       "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="
     },
+    "passport": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/passport/-/passport-0.4.1.tgz",
+      "integrity": "sha512-IxXgZZs8d7uFSt3eqNjM9NQ3g3uQCW5avD8mRNoXV99Yig50vjuaez6dQK2qC0kVWPRTujxY0dWgGfT09adjYg==",
+      "requires": {
+        "passport-strategy": "1.x.x",
+        "pause": "0.0.1"
+      }
+    },
+    "passport-apple": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/passport-apple/-/passport-apple-1.1.1.tgz",
+      "integrity": "sha512-dHsJFO01JD996gH0AoAx07q7FyRZANhgPwmcYDc919IAJrPKLFcUSDaC+nqpnMwehMnEJSPRSxSR+jF7rd+3Hg==",
+      "requires": {
+        "jsonwebtoken": "^8.5.1",
+        "passport-oauth2": "^1.5.0"
+      }
+    },
+    "passport-oauth2": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/passport-oauth2/-/passport-oauth2-1.5.0.tgz",
+      "integrity": "sha512-kqBt6vR/5VlCK8iCx1/KpY42kQ+NEHZwsSyt4Y6STiNjU+wWICG1i8ucc1FapXDGO15C5O5VZz7+7vRzrDPXXQ==",
+      "requires": {
+        "base64url": "3.x.x",
+        "oauth": "0.9.x",
+        "passport-strategy": "1.x.x",
+        "uid2": "0.0.x",
+        "utils-merge": "1.x.x"
+      }
+    },
+    "passport-strategy": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/passport-strategy/-/passport-strategy-1.0.0.tgz",
+      "integrity": "sha1-tVOaqPwiWj0a0XlHbd8ja0QPUuQ="
+    },
     "path-exists": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
@@ -3420,6 +3501,11 @@
       "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
       "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
       "dev": true
+    },
+    "pause": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/pause/-/pause-0.0.1.tgz",
+      "integrity": "sha1-HUCLP9t2kjuVQ9lvtMnf1TXZy10="
     },
     "picomatch": {
       "version": "2.2.2",
@@ -4362,6 +4448,11 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.3.tgz",
       "integrity": "sha512-B3ZIOf1IKeH2ixgHhj6la6xdwR9QrLC5d1VKeCSY4tvkqhF2eqd9O7txNlS0PO3GrBAFIdr3L1ndNwteUbZLYg==",
       "dev": true
+    },
+    "uid2": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/uid2/-/uid2-0.0.3.tgz",
+      "integrity": "sha1-SDEm4Rd03y9xuLY53NeZw3YWK4I="
     },
     "undefsafe": {
       "version": "2.0.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -605,16 +605,6 @@
       "resolved": "https://registry.npmjs.org/app-root-path/-/app-root-path-3.0.0.tgz",
       "integrity": "sha512-qMcx+Gy2UZynHjOHOIXPNvpf+9cjvk3cWrBBK7zg4gH9+clobJRb9NGzcT7mQTcV/6Gm/1WelUtqxVXnNlrwcw=="
     },
-    "apple-auth": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/apple-auth/-/apple-auth-1.0.7.tgz",
-      "integrity": "sha512-vfJqy4KtT5KHflxBSemc0mkWuy2GU2wHWaZ6xVWUjPmiXkJcLj5jB3IeCbDLF4wN+ZStjOQXZWfGwccBjclVlA==",
-      "requires": {
-        "axios": "^0.21.1",
-        "express": "^4.17.1",
-        "jsonwebtoken": "^8.5.1"
-      }
-    },
     "arg": {
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
     "@types/passport": "^1.0.6",
     "@types/passport-apple": "^1.1.0",
     "@types/validator": "^13.1.2",
-    "apple-auth": "^1.0.7",
     "axios": "^0.21.1",
     "body-parser": "^1.19.0",
     "cookie-parser": "~1.4.4",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,8 @@
     "@types/http-errors": "^1.8.0",
     "@types/jsonwebtoken": "^8.5.0",
     "@types/morgan": "^1.9.2",
+    "@types/passport": "^1.0.6",
+    "@types/passport-apple": "^1.1.0",
     "@types/validator": "^13.1.2",
     "apple-auth": "^1.0.7",
     "axios": "^0.21.1",
@@ -41,6 +43,8 @@
     "jsonwebtoken": "^8.5.1",
     "morgan": "~1.9.1",
     "mysql2": "^2.2.5",
+    "passport": "^0.4.1",
+    "passport-apple": "^1.1.1",
     "reflect-metadata": "^0.1.13",
     "typeorm": "^0.2.29"
   },

--- a/src/app.ts
+++ b/src/app.ts
@@ -8,6 +8,9 @@ import logger from 'morgan';
 import cors from 'cors';
 import dotenv from 'dotenv';
 import {normalize} from 'path';
+import passport from 'passport';
+
+import {initPassport} from './initAuth';
 
 //use env_values
 dotenv.config();
@@ -28,6 +31,11 @@ createConnection(connectionOptions).then(connection => {
 
   // Express variables
   app.set('port', normalize(process.env.PORT || '3000'));
+
+  // Passport
+  initPassport();
+  app.use(passport.initialize());
+  app.use(passport.session());
 
   // Routing
   app.use(router);

--- a/src/initAuth.ts
+++ b/src/initAuth.ts
@@ -1,0 +1,34 @@
+import passport from 'passport';
+import AppleStrategy from 'passport-apple';
+
+type ContextUser = {
+  id: string;
+  name: string;
+  email: string;
+};
+
+export function initPassport() {
+  passport.serializeUser((user, cb) => {
+    cb(null, JSON.stringify(user));
+  });
+
+  passport.deserializeUser((serialized: string, cb) => {
+    cb(null, JSON.parse(serialized));
+  });
+
+  passport.use(
+    new AppleStrategy(
+      {
+        clientID: 'kr.co.mashup.e9i4.Rrrr.authentication',
+        teamID: 'CHL8Y83Z89',
+        keyID: '2HZYGS7RSJ',
+        callbackURL: 'http://localhost:3000/api/v1/auth/callback',
+        // privateKeyLocation: '../config/AuthKey.p8',
+        passReqToCallback: true,
+      },
+      (req, accessToken, refreshToken, decodedIdToken, profile, cb) => {
+        process.nextTick(() => cb(null, decodedIdToken));
+      }
+    )
+  );
+}

--- a/src/initAuth.ts
+++ b/src/initAuth.ts
@@ -1,11 +1,6 @@
 import passport from 'passport';
 import AppleStrategy from 'passport-apple';
-
-type ContextUser = {
-  id: string;
-  name: string;
-  email: string;
-};
+import path from 'path';
 
 export function initPassport() {
   passport.serializeUser((user, cb) => {
@@ -22,8 +17,10 @@ export function initPassport() {
         clientID: 'kr.co.mashup.e9i4.Rrrr.authentication',
         teamID: 'CHL8Y83Z89',
         keyID: '2HZYGS7RSJ',
-        callbackURL: 'http://localhost:3000/api/v1/auth/callback',
-        // privateKeyLocation: '../config/AuthKey.p8',
+        callbackURL: `${
+          process.env.ROOT_URL ?? 'http://localhost:3000'
+        }/api/v1/auth/callback`,
+        privateKeyLocation: path.join(__dirname, './config/AuthKey.p8'),
         passReqToCallback: true,
       },
       (req, accessToken, refreshToken, decodedIdToken, profile, cb) => {

--- a/src/routes/api/v1/auth.router.ts
+++ b/src/routes/api/v1/auth.router.ts
@@ -1,16 +1,24 @@
-import express, {Router} from 'express';
+import express, {Router, Request} from 'express';
 import passport from 'passport';
+import {Profile} from 'passport-apple';
+
+interface IRequest extends Request {
+  profile?: Profile;
+}
 
 const router: Router = express.Router();
 
-router.get('/signin', passport.authenticate('apple')); // GET /api/v1/auth/signin
+// GET /api/v1/auth/signin
+router.get('/signin', passport.authenticate('apple'));
 
-router.post('/callback', (req, res, next) => {
-  passport.authenticate('apple', (err, profile) => {
-    // req.profile = profile;
+// POST /api/v1/auth/callback
+router.post('/callback', (req: IRequest, res, next) => {
+  passport.authenticate('apple', (err, profile: Profile) => {
+    req.profile = profile;
     console.log(profile);
     next();
   })(req, res, next);
+  return res.json(req.profile);
 });
 
 export default router;

--- a/src/routes/api/v1/auth.router.ts
+++ b/src/routes/api/v1/auth.router.ts
@@ -1,0 +1,16 @@
+import express, {Router} from 'express';
+import passport from 'passport';
+
+const router: Router = express.Router();
+
+router.get('/signin', passport.authenticate('apple')); // GET /api/v1/auth/signin
+
+router.post('/callback', (req, res, next) => {
+  passport.authenticate('apple', (err, profile) => {
+    // req.profile = profile;
+    console.log(profile);
+    next();
+  })(req, res, next);
+});
+
+export default router;

--- a/src/routes/api/v1/index.ts
+++ b/src/routes/api/v1/index.ts
@@ -2,10 +2,12 @@
 import express, {Router} from 'express';
 import userRouter from './user.router';
 import categoryRouter from './category.router';
+import authRouter from './auth.router';
 
 const router: Router = express.Router();
 
 router.use('/user', userRouter);
 router.use('/category', categoryRouter);
+router.use('/auth', authRouter);
 
 export default router;

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -1,69 +1,12 @@
-import express, {application, Request, Response, Router} from 'express';
+import express, {Request, Response, Router} from 'express';
+
 import apiV1Router from './api/v1';
-import fs from 'fs';
-import path from 'path';
-
-import AppleAuth from 'apple-auth';
-import bodyParser from 'body-parser';
-import jwt from 'jsonwebtoken';
-
-const auth = new AppleAuth(
-  {
-    client_id: 'kr.co.mashup.e9i4.Rrrr.authentication',
-    team_id: 'CHL8Y83Z89',
-    key_id: '2HZYGS7RSJ',
-    redirect_uri: 'https://apple-auth.example.com/auth',
-    scope: 'name',
-  },
-  fs.readFileSync(path.join(__dirname, '../config/AuthKey.p8')).toString(),
-  'text'
-);
 
 const router: Router = express.Router();
 
 router.use('/api/v1', apiV1Router);
-
-router.get('/', (req, res) => {
-  console.log(Date().toString() + 'GET /');
-  console.log(
-    fs.readFileSync(path.join(__dirname, '../config/AuthKey.p8')).toString()
-  );
-  res.send(`<a href="${auth.loginURL()}">Sign in with Apple</a>`);
-  // res.send('OK');
-});
-
-router.get('/token', (req, res) => {
-  res.send(auth._tokenGenerator.generate());
-  console.log(
-    'con',
-    auth._tokenGenerator.generate().then(res => console.log(res))
-  );
-});
-
-interface User {
-  [key: string]: any;
-}
-
-router.post('/auth', bodyParser(), async (req, res) => {
-  try {
-    console.log(Date().toString() + 'GET /auth');
-    const response = await auth.accessToken(req.body.code);
-    console.log(response);
-    const idToken = jwt.decode(response.id_token);
-
-    const user: User = {};
-    user.id = idToken.sub;
-
-    if (req.body.user) {
-      const {name} = JSON.parse(req.body.user);
-      user.name = name;
-    }
-
-    res.json(user);
-  } catch (err) {
-    console.error(err);
-    res.send('An error occurred!');
-  }
+router.get('/', (req: Request, res: Response) => {
+  res.send('OK!');
 });
 
 export default router;


### PR DESCRIPTION
기존에 `apple-auth`를 이용하여 작업한 코드를 제거하고 `passport`, `passport-apple` 를 이용하여 애플 로그인 기능을 구현합니다.
배포하기 전 필요한 선작업은 아래와 같습니다.
- `.env` 파일에 `ROOT_URL="https://iguana.ga/"` 코드 추가
- `/src/conifg/` 디렉토리 아래에 `AuthKey.p8` 파일 추가 (AuthKey.p8 파일은 팀 노션에 있습니다.)
- apple developer 설정 중 redirect URL에 https://iguana.ga/ 추가 (ios팀에게 요청 필요)